### PR TITLE
Updated the broken azure devops build status badge doing a global rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # overcore
 
-[![Build Status](https://dev.azure.com/sid1983/sid1983/_apis/build/status/sidm1983.overcore?branchName=master)](https://dev.azure.com/sid1983/sid1983/_build/latest?definitionId=1&branchName=master)
+[![Build Status](https://dev.azure.com/sid1983/overcore/_apis/build/status/sidm1983.overcore?branchName=master)](https://dev.azure.com/sid1983/overcore/_build/latest?definitionId=2&branchName=master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A .NET Standard 2.0 class library full of handy extension methods that is also CLS-Compliant. This class library is free to use for personal and commercial projects.


### PR DESCRIPTION
Rename of corex to overcore and also after creating a new overcore project in Azure Devops.